### PR TITLE
Refactor image rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ out/
 src/language-server/generated/
 tests/
 generated/
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 src/language-server/generated/
 tests/
 generated/
+.DS_Store

--- a/src/cli/generator-html.ts
+++ b/src/cli/generator-html.ts
@@ -120,10 +120,10 @@ const labelFunc = (labelEL: AstNode, ctx:GeneratorContext) => {
 const imageFunc = (imageEL: AstNode, ctx:GeneratorContext) => {
     const el = imageEL as Image;
     if (generateInlineCSS(el, ctx) === '') {
-        return `<img src='${generateExpression(el.imagepath, ctx)}'>`
+        return `<img src='${generateExpression(el.imagepath, ctx)}' alt='${el.altText!==undefined?el.altText:''}'>`
     }
     else {
-        return `<img src='${generateExpression(el.imagepath, ctx)}' style='${generateInlineCSS(el, ctx)}'>`
+        return `<img src='${generateExpression(el.imagepath, ctx)}' alt='${el.altText!==undefined?el.altText:''}' style='${generateInlineCSS(el, ctx)}'>`
     }
 }
 

--- a/src/language-server/simple-ui.langium
+++ b/src/language-server/simple-ui.langium
@@ -82,7 +82,7 @@ Link:
     'link' linkurl=Expression ('{' 'linktext:' linktext=Expression '}')?;
 
 Image:
-    'image' imagepath=Expression ('alt' altText=STRING)? ('{' (css+=CSSProperties(',' css+=CSSProperties)*) '}')?;
+    'image' imagepath=Expression ('alt:' altText=STRING)? ('{' (css+=CSSProperties(',' css+=CSSProperties)*) '}')?;
 
 Linebreak:    
     {Linebreak} 'linebreak';

--- a/src/language-server/simple-ui.langium
+++ b/src/language-server/simple-ui.langium
@@ -82,7 +82,7 @@ Link:
     'link' linkurl=Expression ('{' 'linktext:' linktext=Expression '}')?;
 
 Image:
-    'image' imagepath=Expression ('{' (css+=CSSProperties(',' css+=CSSProperties)*) '}')?;
+    'image' imagepath=Expression ('alt' altText=STRING)? ('{' (css+=CSSProperties(',' css+=CSSProperties)*) '}')?;
 
 Linebreak:    
     {Linebreak} 'linebreak';

--- a/syntaxes/simple-ui.tmLanguage.json
+++ b/syntaxes/simple-ui.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.simple-ui",
-      "match": "\\b(background-color|button|component|div|font-size|function|getTextbox|header|height|image|label|linebreak|link|number|paragraph|popup|string|text-color|textbox|title|topbar|usecomponent|width)\\b|\\b(for:|headerlevel:|linktext:|onClick:|placeholdertext:)\\B"
+      "match": "\\b(alt|background-color|button|component|div|font-size|function|getTextbox|header|height|image|label|linebreak|link|number|paragraph|popup|string|text-color|textbox|title|topbar|usecomponent|width)\\b|\\b(for:|headerlevel:|linktext:|onClick:|placeholdertext:)\\B"
     },
     {
       "name": "string.quoted.double.simple-ui",


### PR DESCRIPTION
I added the option to add an `alt` attribute when declaring an `image`. It feeds a property called `altText` of type string.

If the `alt` keyword is omitted, the attribute in the html tag will be `alt=''`