### PR TITLE
Added nested CSS feature

### DIFF
--- a/src/cli/generator-css.ts
+++ b/src/cli/generator-css.ts
@@ -51,12 +51,14 @@ export function generateCSS(model: SimpleUi, filePath: string, destination: stri
 }
 
 export function copyCSSClass(name: string) {
-    const regex = new RegExp(`\\.${name}[\\s]?\\\{[\\s\\S]*?\\\}`);
+    const regex = new RegExp(`\\.${name}[\\s\\S]+?\{[\\s\\S]*?\}`,'gm');
     const fileContent = fs.readFileSync(path.resolve(__dirname + '../../../src/assets/base.css'),'utf8');
-    if(fileContent.includes(`.${name}`)) {
-        let result = '';
-        result += regex.exec(fileContent);
-        if(!copiedCSS.includes(result))
-            copiedCSS.push(result);
+    const regexResult = fileContent.match(regex);
+
+    if(regexResult){
+    const output = regexResult.join('\n');
+        if(!copiedCSS.includes(output)){
+            copiedCSS.push(output);
+        }
     }
 }

--- a/src/language-server/simple-ui-validator.ts
+++ b/src/language-server/simple-ui-validator.ts
@@ -96,7 +96,7 @@ export class SimpleUiValidator {
     }
     checkCSSClasses(classes: CSSClasses, accept: ValidationAcceptor): void {
         const fileContent = fs.readFileSync(path.resolve(__dirname + '../../../src/assets/base.css'),'utf8');
-        let regex = /(?<=\.).*?(?=[\s]?{)/gm;
+        let regex = new RegExp('(?<=\\.)[a-zA-Z\\d\\-]*','gm');
         let cssClasses = fileContent.match(regex);
         classes.names.forEach(element => {
             if(!cssClasses?.includes(element))

--- a/syntaxes/simple-ui.tmLanguage.json
+++ b/syntaxes/simple-ui.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.simple-ui",
-      "match": "\\b(background-color|border|button|center|classes|component|dashed-border|div|dotted-border|fixed|flex-container|font-size|function|getTextbox|heading|height|hidden|icon|image|labelAfter|linebreak|link|no-scrollbar|number|paragraph|popup|scrollbar|shadow|smooth-scroll|string|text-color|textbox|title|topbar|usecomponent|width)\\b|\\b(alt:|for:|labeltext:|level:|linktext:|onClick:|placeholdertext:)\\B"
+      "match": "\\b(background-color|button|classes|component|div|fixed|font-size|function|getTextbox|heading|height|icon|image|labelAfter|linebreak|link|number|paragraph|popup|string|text-color|textbox|title|topbar|usecomponent|width)\\b|\\b(alt:|labeltext:|level:|linktext:|onClick:|placeholdertext:)\\B"
     },
     {
       "name": "string.quoted.double.simple-ui",


### PR DESCRIPTION
It is now possible to work with "nested" CSS.

CSS classes like `.class > element` or `.class element` are now added to the generated stylesheet.

I also modified the validator so that if `.class` is not defined on its own but only with element selectors, it will not throw an error. 