### PR TITLE
Added topbar style to base.css

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -4,12 +4,12 @@
     overflow: hidden;
     padding: 1rem 1%;
 }
-.topbar > nav > a:any-link{
+.topbar > nav > a:any-link {
     color: #f2f2f2;
     font-size: 1.5rem;
     text-decoration: none;
 }
-.topbar--fixed{
+.topbar--fixed {
     position: fixed;
     top: 0;
 }

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -1,3 +1,19 @@
+.topbar {
+    width:100%;
+    background-color: #333;
+    overflow: hidden;
+    padding: 1rem 1%;
+}
+.topbar > nav > a:any-link{
+    color: #f2f2f2;
+    font-size: 1.5rem;
+    text-decoration: none;
+}
+.topbar--fixed{
+    position: fixed;
+    top: 0;
+}
+
 .center {
     display: flex;
     align-items: center;

--- a/src/cli/generator-css.ts
+++ b/src/cli/generator-css.ts
@@ -17,30 +17,8 @@ export function generateCSS(model: SimpleUi, filePath: string, destination: stri
         indentContent.append('font-family: Arial, Helvetica, sans-serif;', NL);
     });
     fileNode.append('}', NL);
-    //.topbar
-    fileNode.append('.topbar {',NL);
-    fileNode.indent(indentContent => {
-        indentContent.append('width:100%;',NL);
-        indentContent.append('background-color: #333;',NL);
-        indentContent.append('overflow: hidden;',NL);
-        indentContent.append('padding: 1rem 1%;',NL);
-    });
-    fileNode.append('}',NL);
-    fileNode.append('.topbar > nav > a:any-link{',NL);
-    fileNode.indent(indentContent => {
-        indentContent.append('color: #f2f2f2;',NL);
-        indentContent.append('font-size: 1.5rem;',NL);
-        indentContent.append('text-decoration: none;',NL);
-    });
-    fileNode.append('}',NL);
-    //.topbar--fixed
-    fileNode.append('.topbar--fixed{',NL);
-    fileNode.indent(indentContent => {
-        indentContent.append('position: fixed;',NL);
-        indentContent.append('top: 0;',NL);
-    })
-    fileNode.append('}',NL);
-    //CSS from base.css (only classes used in the input file)
+
+    // CSS from base.css (only classes used in the input file)
     fileNode.append(copiedCSS.join("\n"));
 
     if (!fs.existsSync(data.destination)) {

--- a/src/cli/generator-html.ts
+++ b/src/cli/generator-html.ts
@@ -147,6 +147,7 @@ const useComponentFunc = (UseComponentEL: AstNode, ctx: GeneratorContext) => {
 const topbarFunc = (TopbarEl: AstNode, ctx: GeneratorContext) => {
     const el = TopbarEl as Topbar;
     const topbarNode = new CompositeGeneratorNode();
+    copyCSSClass('topbar');
     topbarNode.append(`<header class='topbar ${el.fixed?'topbar--fixed':''}' class='${generateCSSClasses(el.classes)}' style='${generateInlineCSS(el,ctx)}'>`,NL);
     topbarNode.indent(topbarContent => {
         topbarContent.append(`<nav>`,NL);
@@ -156,23 +157,6 @@ const topbarFunc = (TopbarEl: AstNode, ctx: GeneratorContext) => {
         topbarContent.append(`</nav>`,NL);
     })
     topbarNode.append(`</header>`);
-  
-    /*previous way of generating html
-    if (generateInlineCSS(el, ctx) === '') {
-        topbarNode.append(`<div ${classString != '' ? classString : ''} style='background-color: #333; overflow: hidden;'>`, NL)
-        topbarNode.indent(topbarContent => {
-            topbarContent.append(`<p style='color: #f2f2f2; margin-left: 1%; font-size: 17px;'>${generateExpression(el.value, ctx)}</p>`)
-        })
-        topbarNode.append('</div>')
-    }
-    else {
-        topbarNode.append(`<div ${classString != '' ? classString : ''}  style='${generateInlineCSS(el, ctx)} overflow: hidden;'>`, NL)
-        topbarNode.indent(topbarContent => {
-            topbarContent.append(`<p style='${generateInlineCSS(el, ctx)} margin-left: 1%;'>${generateExpression(el.value, ctx)}</p>`)
-        })
-        topbarNode.append('</div>')
-    }
-    */
     return topbarNode
 }
 


### PR DESCRIPTION
The whole topbar style is now in the base.css file and only gets copied when the topbar is used.
```css
.topbar {
    width:100%;
    background-color: #333;
    overflow: hidden;
    padding: 1rem 1%;
}
.topbar > nav > a:any-link{
    color: #f2f2f2;
    font-size: 1.5rem;
    text-decoration: none;
}
.topbar--fixed{
    position: fixed;
    top: 0;
}
```