### PR TITLE
Fix the usage of SymbolReferences without using an ID

### DIFF
--- a/src/cli/generator-html.ts
+++ b/src/cli/generator-html.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { AstNode, CompositeGeneratorNode, NL, processGeneratorNode } from 'langium';
 import { integer } from 'vscode-languageserver-types';
-import { BodyElement, Button, CSSProperty, Div, Expression, Footer, HeadElement, Heading, Icon, Image, isElementId, isNumberExpression, isOperation, isStringExpression, isSymbolReference, Link, NestingElement, Paragraph, Parameter, Section, SimpleExpression, SimpleUi, SimpleUIAstType, SingleElement, Textbox, Title, Topbar, UseComponent } from '../language-server/generated/ast';
+import { BodyElement, Button, CSSProperty, Div, Expression, Footer, HeadElement, Heading, Icon, Image, isNumberExpression, isOperation, isStringExpression, isSymbolReference, Link, NestingElement, Paragraph, Parameter, Section, SimpleExpression, SimpleUi, SimpleUIAstType, SingleElement, Textbox, Title, Topbar, UseComponent } from '../language-server/generated/ast';
 import { extractDestinationAndName } from './cli-util';
 import { copyCSSClass } from './generator-css';
 
@@ -132,7 +132,7 @@ function divFunc(element: Div, ctx: GeneratorContext) : CompositeGeneratorNode {
     const fileNode = new CompositeGeneratorNode();
     
     fileNode.append(`<div`,
-    generateExpression(element.name, ctx)?` id="${generateExpression(element.name, ctx)}"`:'',
+    element.name?` id="${element.name}"`:'',
     formatCSS(element, ctx),
     '>',
      NL);
@@ -147,7 +147,7 @@ function divFunc(element: Div, ctx: GeneratorContext) : CompositeGeneratorNode {
 function sectionFunc(element: Section, ctx: GeneratorContext) : CompositeGeneratorNode {
     const fileNode = new CompositeGeneratorNode();
     fileNode.append(`<section`,
-    generateExpression(element.name, ctx) ? ` id="${generateExpression(element.name, ctx)}"` : '',
+    element.name ? ` id="${element.name}"` : '',
     formatCSS(element, ctx),
     `>`, NL);
 
@@ -162,7 +162,7 @@ function sectionFunc(element: Section, ctx: GeneratorContext) : CompositeGenerat
 
 function paragraphFunc(element: Paragraph, ctx: GeneratorContext) : string { 
     return `<p` + 
-    (generateExpression(element.name, ctx) ? ` id="${generateExpression(element.name, ctx)}"` : '') + 
+    (element.name ? ` id="${element.name}"` : '') + 
     formatCSS(element, ctx) +
     '>' + 
     generateExpression(element.text, ctx) + '</p>';
@@ -170,7 +170,7 @@ function paragraphFunc(element: Paragraph, ctx: GeneratorContext) : string {
 
 function buttonFunc(element: Button, ctx: GeneratorContext) : string {
     return `<button` + 
-    (generateExpression(element.name, ctx) ? ` id="${generateExpression(element.name, ctx)}"` : '' ) +
+    (element.name ? ` id="${element.name}"` : '' ) +
     formatCSS(element, ctx) + 
     (element.onclickaction ? ` onclick="${generateParameters(element.arguments, ctx)}"` : '') + 
     `>` + 
@@ -215,7 +215,7 @@ function linebreakFunc() {
 
 function imageFunc(element: Image, ctx: GeneratorContext) {
     return `<img`+
-    (generateExpression(element.name, ctx) ? ` id="${generateExpression(element.name, ctx)}"` : '') + 
+    (element.name ? ` id="${element.name}"` : '') + 
     ` src="${generateExpression(element.imagePath, ctx)}"` + 
     ` alt=` + 
     (element.altText ? `"${generateExpression(element.altText, ctx)}"` : '""') +
@@ -225,7 +225,7 @@ function imageFunc(element: Image, ctx: GeneratorContext) {
 
 function headingFunc(element: Heading, ctx: GeneratorContext) {
     return `<h${element.level}` + 
-    (generateExpression(element.name, ctx) ? ` id="${generateExpression(element.name, ctx)}"` : '') + 
+    (element.name ? ` id="${element.name}"` : '') + 
     formatCSS(element, ctx) + 
     `>` + 
     generateExpression(element.text, ctx) + 
@@ -325,12 +325,6 @@ function generateExpression(expression: Expression | SimpleExpression, ctx: Gene
             result = eval(left + expression.operator + right)
             return (result)
         }
-    }
-    else if (isElementId(expression)) {
-        return expression.name
-    }
-    else if (typeof(expression) === 'undefined') {
-        return ''
     }
     else {
         throw new Error('Unhandled Expression type: ' + expression.$type)

--- a/src/cli/generator-html.ts
+++ b/src/cli/generator-html.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { AstNode, CompositeGeneratorNode, NL, processGeneratorNode } from 'langium';
 import { integer } from 'vscode-languageserver-types';
-import { BodyElement, Button, CSSProperty, Div, Expression, Footer, HeadElement, Heading, Icon, Image, isNumberExpression, isOperation, isStringExpression, isSymbolReference, Link, NestingElement, Paragraph, Parameter, Section, SimpleExpression, SimpleUi, SimpleUIAstType, SingleElement, Textbox, Title, Topbar, UseComponent } from '../language-server/generated/ast';
+import { BodyElement, Button, CSSProperty, Div, Expression, Footer, HeadElement, Heading, Icon, Image, isElementId, isNumberExpression, isOperation, isStringExpression, isSymbolReference, Link, NestingElement, Paragraph, Parameter, Section, SimpleExpression, SimpleUi, SimpleUIAstType, SingleElement, Textbox, Title, Topbar, UseComponent } from '../language-server/generated/ast';
 import { extractDestinationAndName } from './cli-util';
 import { copyCSSClass } from './generator-css';
 
@@ -132,7 +132,7 @@ function divFunc(element: Div, ctx: GeneratorContext) : CompositeGeneratorNode {
     const fileNode = new CompositeGeneratorNode();
     
     fileNode.append(`<div`,
-    element.name?` id="${element.name}"`:'',
+    generateExpression(element.name, ctx)?` id="${generateExpression(element.name, ctx)}"`:'',
     formatCSS(element, ctx),
     '>',
      NL);
@@ -147,7 +147,7 @@ function divFunc(element: Div, ctx: GeneratorContext) : CompositeGeneratorNode {
 function sectionFunc(element: Section, ctx: GeneratorContext) : CompositeGeneratorNode {
     const fileNode = new CompositeGeneratorNode();
     fileNode.append(`<section`,
-    element.name ? ` id="${element.name}"` : '',
+    generateExpression(element.name, ctx) ? ` id="${generateExpression(element.name, ctx)}"` : '',
     formatCSS(element, ctx),
     `>`, NL);
 
@@ -162,7 +162,7 @@ function sectionFunc(element: Section, ctx: GeneratorContext) : CompositeGenerat
 
 function paragraphFunc(element: Paragraph, ctx: GeneratorContext) : string { 
     return `<p` + 
-    (element.name ? ` id="${element.name}"` : '') + 
+    (generateExpression(element.name, ctx) ? ` id="${generateExpression(element.name, ctx)}"` : '') + 
     formatCSS(element, ctx) +
     '>' + 
     generateExpression(element.text, ctx) + '</p>';
@@ -170,7 +170,7 @@ function paragraphFunc(element: Paragraph, ctx: GeneratorContext) : string {
 
 function buttonFunc(element: Button, ctx: GeneratorContext) : string {
     return `<button` + 
-    (element.name ? ` id="${element.name}"` : '' ) +
+    (generateExpression(element.name, ctx) ? ` id="${generateExpression(element.name, ctx)}"` : '' ) +
     formatCSS(element, ctx) + 
     (element.onclickaction ? ` onclick="${generateParameters(element.arguments, ctx)}"` : '') + 
     `>` + 
@@ -215,7 +215,7 @@ function linebreakFunc() {
 
 function imageFunc(element: Image, ctx: GeneratorContext) {
     return `<img`+
-    (element.name ? ` id="${element.name}"` : '') + 
+    (generateExpression(element.name, ctx) ? ` id="${generateExpression(element.name, ctx)}"` : '') + 
     ` src="${generateExpression(element.imagePath, ctx)}"` + 
     ` alt=` + 
     (element.altText ? `"${generateExpression(element.altText, ctx)}"` : '""') +
@@ -225,7 +225,7 @@ function imageFunc(element: Image, ctx: GeneratorContext) {
 
 function headingFunc(element: Heading, ctx: GeneratorContext) {
     return `<h${element.level}` + 
-    (element.name ? ` id="${element.name}"` : '') + 
+    (generateExpression(element.name, ctx) ? ` id="${generateExpression(element.name, ctx)}"` : '') + 
     formatCSS(element, ctx) + 
     `>` + 
     generateExpression(element.text, ctx) + 
@@ -325,6 +325,12 @@ function generateExpression(expression: Expression | SimpleExpression, ctx: Gene
             result = eval(left + expression.operator + right)
             return (result)
         }
+    }
+    else if (isElementId(expression)) {
+        return expression.name
+    }
+    else if (typeof(expression) === 'undefined') {
+        return ''
     }
     else {
         throw new Error('Unhandled Expression type: ' + expression.$type)

--- a/src/language-server/simple-ui.langium
+++ b/src/language-server/simple-ui.langium
@@ -32,36 +32,36 @@ CSSClass returns string:
     ID (('-')* ID)*;
 
 InlineCSS:
-   ('styles' '[' (properties+=CSSProperty(',' properties+=CSSProperty)*)? ']')?;
+    ('styles' '[' (properties+=CSSProperty(',' properties+=CSSProperty)*)? ']')?;
 
 CSSProperty:
     property=('text-color'|'font-size'|'width'|'height'|'background-color')':' value=Expression;
 
 // NESTING HTML ELEMENTS
 Div: 
-    'div' name=ID?;  
+    'div' name=ElementId?;  
 
 Section: 
-    'section' name=ID? description=STRING?;
+    'section' name=ElementId? description=STRING?;
 
 // SINGLE HTML ELEMENTS
 Paragraph:
-    'paragraph' name=ID? text=Expression;
+    'paragraph' name=ElementId? text=Expression;
 
 Heading:
-    'heading' name=ID? 'level:'level=INT text=Expression;
+    'heading' name=ElementId? 'level:'level=INT text=Expression;
 
 Image:
-    'image' name=ID? imagePath=Expression ('alt:' altText=Expression)?;
+    'image' name=ElementId? imagePath=Expression ('alt:' altText=Expression)?;
 
 Textbox:
-    'textbox' name=ID ('placeholder:' placeholderText=Expression)? ('label:' labelText=Expression (labelAfter?='labelafter')?)?;
+    'textbox' ElementId ('placeholder:' placeholderText=Expression)? ('label:' labelText=Expression (labelAfter?='labelafter')?)?;
 
 Button:
-    'button' name=ID? buttonText=Expression ('{' 'onClick:' onclickaction=[JSFunction:ID]('('(arguments+=Expression(',' arguments+=Expression)*)?')') '}')?;
+    'button' name=ElementId? buttonText=Expression ('{' 'onClick:' onclickaction=[JSFunction:ID]('('(arguments+=Expression(',' arguments+=Expression)*)?')') '}')?;
 
 Link:
-    'link' name=ID? linkUrl=Expression ('text:' linkText=Expression)?;
+    'link' name=ElementId? linkUrl=Expression ('text:' linkText=Expression)?;
 
 Linebreak:    
     {Linebreak} 'linebreak';
@@ -114,6 +114,9 @@ NumberExpression:
 
 SymbolReference:
     symbol=[Parameter];
+
+ElementId:
+    'id:' name=ID;
 
 
 // JS implementation

--- a/src/language-server/simple-ui.langium
+++ b/src/language-server/simple-ui.langium
@@ -115,7 +115,7 @@ NumberExpression:
 SymbolReference:
     symbol=[Parameter];
 
-ElementId:
+ElementId returns STRING:
     'id:' name=ID;
 
 

--- a/syntaxes/simple-ui.tmLanguage.json
+++ b/syntaxes/simple-ui.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.simple-ui",
-      "match": "\\b(background-color|button|classes|component|div|fixed|font-size|footer|function|getTextbox|heading|height|icon|image|labelafter|linebreak|link|number|paragraph|popup|section|string|styles|text-color|textbox|title|topbar|usecomponent|width)\\b|\\b(alt:|label:|level:|onClick:|placeholder:|text:)\\B"
+      "match": "\\b(background-color|button|classes|component|div|fixed|font-size|footer|function|getTextbox|heading|height|icon|image|labelafter|linebreak|link|number|paragraph|popup|section|string|styles|text-color|textbox|title|topbar|usecomponent|width)\\b|\\b(alt:|id:|label:|level:|onClick:|placeholder:|text:)\\B"
     },
     {
       "name": "string.quoted.double.simple-ui",


### PR DESCRIPTION
Before it was impossible to use SymbolReferences without an giving an ID because the generator would confuse the SymbolReference as an ID. This is now fixed by adding the 'id:' keyword which is needed to define an id to make it unique for the parser to handle.