### PR TITLE
Alternative: Fix the usage of SymbolReferences without using an ID

### DIFF
--- a/src/language-server/simple-ui.langium
+++ b/src/language-server/simple-ui.langium
@@ -113,7 +113,7 @@ NumberExpression:
     value=INT;
 
 SymbolReference:
-    symbol=[Parameter];
+    '$[' symbol=[Parameter] ']';
 
 
 // JS implementation

--- a/src/language-server/simple-ui.langium
+++ b/src/language-server/simple-ui.langium
@@ -39,29 +39,29 @@ CSSProperty:
 
 // NESTING HTML ELEMENTS
 Div: 
-    'div' name=ElementName?;  
+    'div' ElementName?;  
 
 Section: 
-    'section' name=ElementName? description=STRING?;
+    'section' ElementName? description=STRING?;
 
 // SINGLE HTML ELEMENTS
 Paragraph:
-    'paragraph' name=ElementName? text=Expression;
+    'paragraph' ElementName? text=Expression;
 
 Heading:
-    'heading' name=ElementName? 'level:'level=INT text=Expression;
+    'heading' ElementName? 'level:'level=INT text=Expression;
 
 Image:
-    'image' name=ElementName? imagePath=Expression ('alt:' altText=Expression)?;
+    'image' ElementName? imagePath=Expression ('alt:' altText=Expression)?;
 
 Textbox:
-    'textbox' name=ElementName ('placeholder:' placeholderText=Expression)? ('label:' labelText=Expression (labelAfter?='labelafter')?)?;
+    'textbox' ElementName ('placeholder:' placeholderText=Expression)? ('label:' labelText=Expression (labelAfter?='labelafter')?)?;
 
 Button:
-    'button' name=ElementName? buttonText=Expression ('{' 'onClick:' onclickaction=[JSFunction:ID]('('(arguments+=Expression(',' arguments+=Expression)*)?')') '}')?;
+    'button' ElementName? buttonText=Expression ('{' 'onClick:' onclickaction=[JSFunction:ID]('('(arguments+=Expression(',' arguments+=Expression)*)?')') '}')?;
 
 Link:
-    'link' name=ElementName? linkUrl=Expression ('text:' linkText=Expression)?;
+    'link' ElementName? linkUrl=Expression ('text:' linkText=Expression)?;
 
 Linebreak:    
     {Linebreak} 'linebreak';
@@ -72,8 +72,8 @@ Topbar:
 Footer:
     'footer' value=Expression;
 
-ElementName returns string:
-    ID;
+fragment ElementName:
+    name=ID;
 
 // HEAD ELEMENTS
 Title:

--- a/src/language-server/simple-ui.langium
+++ b/src/language-server/simple-ui.langium
@@ -32,36 +32,36 @@ CSSClass returns string:
     ID (('-')* ID)*;
 
 InlineCSS:
-   ('styles' '[' (properties+=CSSProperty(',' properties+=CSSProperty)*)? ']')?;
+    ('styles' '[' (properties+=CSSProperty(',' properties+=CSSProperty)*)? ']')?;
 
 CSSProperty:
     property=('text-color'|'font-size'|'width'|'height'|'background-color')':' value=Expression;
 
 // NESTING HTML ELEMENTS
 Div: 
-    'div' name=ID?;  
+    'div' name=ElementName?;  
 
 Section: 
-    'section' name=ID? description=STRING?;
+    'section' name=ElementName? description=STRING?;
 
 // SINGLE HTML ELEMENTS
 Paragraph:
-    'paragraph' name=ID? text=Expression;
+    'paragraph' name=ElementName? text=Expression;
 
 Heading:
-    'heading' name=ID? 'level:'level=INT text=Expression;
+    'heading' name=ElementName? 'level:'level=INT text=Expression;
 
 Image:
-    'image' name=ID? imagePath=Expression ('alt:' altText=Expression)?;
+    'image' name=ElementName? imagePath=Expression ('alt:' altText=Expression)?;
 
 Textbox:
-    'textbox' name=ID ('placeholder:' placeholderText=Expression)? ('label:' labelText=Expression (labelAfter?='labelafter')?)?;
+    'textbox' name=ElementName ('placeholder:' placeholderText=Expression)? ('label:' labelText=Expression (labelAfter?='labelafter')?)?;
 
 Button:
-    'button' name=ID? buttonText=Expression ('{' 'onClick:' onclickaction=[JSFunction:ID]('('(arguments+=Expression(',' arguments+=Expression)*)?')') '}')?;
+    'button' name=ElementName? buttonText=Expression ('{' 'onClick:' onclickaction=[JSFunction:ID]('('(arguments+=Expression(',' arguments+=Expression)*)?')') '}')?;
 
 Link:
-    'link' name=ID? linkUrl=Expression ('text:' linkText=Expression)?;
+    'link' name=ElementName? linkUrl=Expression ('text:' linkText=Expression)?;
 
 Linebreak:    
     {Linebreak} 'linebreak';
@@ -71,6 +71,9 @@ Topbar:
 
 Footer:
     'footer' value=Expression;
+
+ElementName returns string:
+    ID;
 
 // HEAD ELEMENTS
 Title:


### PR DESCRIPTION
Before it was impossible to use SymbolReferences without an giving an ID because the generator would confuse the SymbolReference as an ID. This is now fixed by adding keywords to SymbolReferences which is needed to define an SymbolReference to make it unique for the parser to handle.