### PR TITLE
Upgrade to Langium 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "commander": "^8.0.0",
                 "generator-langium": "^0.2.1",
-                "langium": "0.3.0-next.ee4fc4e",
+                "langium": "0.3.0",
                 "vscode-languageclient": "^7.0.0",
                 "vscode-languageserver": "^7.0.0"
             },
@@ -23,7 +23,7 @@
                 "@typescript-eslint/eslint-plugin": "^4.14.1",
                 "@typescript-eslint/parser": "^4.14.1",
                 "eslint": "^7.19.0",
-                "langium-cli": "0.3.0-next.ee4fc4e",
+                "langium-cli": "0.3.0",
                 "source-map-loader": "^3.0.0",
                 "ts-loader": "^9.2.3",
                 "typescript": "^4.1.3",
@@ -2041,9 +2041,9 @@
             }
         },
         "node_modules/langium": {
-            "version": "0.3.0-next.ee4fc4e",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-0.3.0-next.ee4fc4e.tgz",
-            "integrity": "sha512-nQRb1gOgibZczm3aI0Gm4Z9mYj4As4bDgXBGREenLywqit3cbt4Vl9IyIS36R++2z+bpHUm2q8A+j6CLHMkHrQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/langium/-/langium-0.3.0.tgz",
+            "integrity": "sha512-7v6VFmzj+LReOOFWegVMlaR6CbUr6cYOW5B60jVawJ066jrBq2omYToGR74KKRsuj7egseUNWWrfsYB3UR9klw==",
             "dependencies": {
                 "chevrotain": "^9.1.0",
                 "vscode-languageserver": "^7.0.0",
@@ -2055,16 +2055,16 @@
             }
         },
         "node_modules/langium-cli": {
-            "version": "0.3.0-next.ee4fc4e",
-            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-0.3.0-next.ee4fc4e.tgz",
-            "integrity": "sha512-10GOCPPl+aUG+jhhLs375t4+L2p+hmhvPWEOuQrpQKYRV0DQuKOh6NvBKClaI8v6RA48jTf5yvoX6/yKjjVXuQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-0.3.0.tgz",
+            "integrity": "sha512-jMfcrsVbqpSMS56DyxtmgDvQZFJk4ej7B6DKBinAu+Sw2LLobUgSuL3RyLV/bZLZfpdhLdF6pSiwQWq5lu2djQ==",
             "dev": true,
             "dependencies": {
                 "colors": "^1.4.0",
                 "commander": "^7.2.0",
                 "fs-extra": "^9.1.0",
                 "jsonschema": "^1.4.0",
-                "langium": "0.3.0-next.ee4fc4e",
+                "langium": "~0.3.0",
                 "lodash": "^4.17.21"
             },
             "bin": {
@@ -5190,9 +5190,9 @@
             "dev": true
         },
         "langium": {
-            "version": "0.3.0-next.ee4fc4e",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-0.3.0-next.ee4fc4e.tgz",
-            "integrity": "sha512-nQRb1gOgibZczm3aI0Gm4Z9mYj4As4bDgXBGREenLywqit3cbt4Vl9IyIS36R++2z+bpHUm2q8A+j6CLHMkHrQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/langium/-/langium-0.3.0.tgz",
+            "integrity": "sha512-7v6VFmzj+LReOOFWegVMlaR6CbUr6cYOW5B60jVawJ066jrBq2omYToGR74KKRsuj7egseUNWWrfsYB3UR9klw==",
             "requires": {
                 "chevrotain": "^9.1.0",
                 "vscode-languageserver": "^7.0.0",
@@ -5201,16 +5201,16 @@
             }
         },
         "langium-cli": {
-            "version": "0.3.0-next.ee4fc4e",
-            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-0.3.0-next.ee4fc4e.tgz",
-            "integrity": "sha512-10GOCPPl+aUG+jhhLs375t4+L2p+hmhvPWEOuQrpQKYRV0DQuKOh6NvBKClaI8v6RA48jTf5yvoX6/yKjjVXuQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-0.3.0.tgz",
+            "integrity": "sha512-jMfcrsVbqpSMS56DyxtmgDvQZFJk4ej7B6DKBinAu+Sw2LLobUgSuL3RyLV/bZLZfpdhLdF6pSiwQWq5lu2djQ==",
             "dev": true,
             "requires": {
                 "colors": "^1.4.0",
                 "commander": "^7.2.0",
                 "fs-extra": "^9.1.0",
                 "jsonschema": "^1.4.0",
-                "langium": "0.3.0-next.ee4fc4e",
+                "langium": "~0.3.0",
                 "lodash": "^4.17.21"
             },
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "commander": "^8.0.0",
                 "generator-langium": "^0.2.1",
-                "langium": "0.3.0-next.5e9d27d",
+                "langium": "0.3.0-next.ee4fc4e",
                 "vscode-languageclient": "^7.0.0",
                 "vscode-languageserver": "^7.0.0"
             },
@@ -23,7 +23,7 @@
                 "@typescript-eslint/eslint-plugin": "^4.14.1",
                 "@typescript-eslint/parser": "^4.14.1",
                 "eslint": "^7.19.0",
-                "langium-cli": "0.3.0-next.5e9d27d",
+                "langium-cli": "0.3.0-next.ee4fc4e",
                 "source-map-loader": "^3.0.0",
                 "ts-loader": "^9.2.3",
                 "typescript": "^4.1.3",
@@ -2041,9 +2041,9 @@
             }
         },
         "node_modules/langium": {
-            "version": "0.3.0-next.5e9d27d",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-0.3.0-next.5e9d27d.tgz",
-            "integrity": "sha512-bsRFqmDdHmLH0yCSdkchvxVDzf1lebIbB4K1fEry7U5XETjK+ZltNoWlaKDbQfc2pzRTTEKVbUm6V627CPfZ8Q==",
+            "version": "0.3.0-next.ee4fc4e",
+            "resolved": "https://registry.npmjs.org/langium/-/langium-0.3.0-next.ee4fc4e.tgz",
+            "integrity": "sha512-nQRb1gOgibZczm3aI0Gm4Z9mYj4As4bDgXBGREenLywqit3cbt4Vl9IyIS36R++2z+bpHUm2q8A+j6CLHMkHrQ==",
             "dependencies": {
                 "chevrotain": "^9.1.0",
                 "vscode-languageserver": "^7.0.0",
@@ -2055,16 +2055,16 @@
             }
         },
         "node_modules/langium-cli": {
-            "version": "0.3.0-next.5e9d27d",
-            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-0.3.0-next.5e9d27d.tgz",
-            "integrity": "sha512-oH8psUBQhcM2EmtGwylRpovYh0HgejZUgQe9GOpRyAimv1LiimDPUwFqPrH1y7q0dnG2veUF7+NNCeYJoANz4g==",
+            "version": "0.3.0-next.ee4fc4e",
+            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-0.3.0-next.ee4fc4e.tgz",
+            "integrity": "sha512-10GOCPPl+aUG+jhhLs375t4+L2p+hmhvPWEOuQrpQKYRV0DQuKOh6NvBKClaI8v6RA48jTf5yvoX6/yKjjVXuQ==",
             "dev": true,
             "dependencies": {
                 "colors": "^1.4.0",
                 "commander": "^7.2.0",
                 "fs-extra": "^9.1.0",
                 "jsonschema": "^1.4.0",
-                "langium": "0.3.0-next.5e9d27d",
+                "langium": "0.3.0-next.ee4fc4e",
                 "lodash": "^4.17.21"
             },
             "bin": {
@@ -5190,9 +5190,9 @@
             "dev": true
         },
         "langium": {
-            "version": "0.3.0-next.5e9d27d",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-0.3.0-next.5e9d27d.tgz",
-            "integrity": "sha512-bsRFqmDdHmLH0yCSdkchvxVDzf1lebIbB4K1fEry7U5XETjK+ZltNoWlaKDbQfc2pzRTTEKVbUm6V627CPfZ8Q==",
+            "version": "0.3.0-next.ee4fc4e",
+            "resolved": "https://registry.npmjs.org/langium/-/langium-0.3.0-next.ee4fc4e.tgz",
+            "integrity": "sha512-nQRb1gOgibZczm3aI0Gm4Z9mYj4As4bDgXBGREenLywqit3cbt4Vl9IyIS36R++2z+bpHUm2q8A+j6CLHMkHrQ==",
             "requires": {
                 "chevrotain": "^9.1.0",
                 "vscode-languageserver": "^7.0.0",
@@ -5201,16 +5201,16 @@
             }
         },
         "langium-cli": {
-            "version": "0.3.0-next.5e9d27d",
-            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-0.3.0-next.5e9d27d.tgz",
-            "integrity": "sha512-oH8psUBQhcM2EmtGwylRpovYh0HgejZUgQe9GOpRyAimv1LiimDPUwFqPrH1y7q0dnG2veUF7+NNCeYJoANz4g==",
+            "version": "0.3.0-next.ee4fc4e",
+            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-0.3.0-next.ee4fc4e.tgz",
+            "integrity": "sha512-10GOCPPl+aUG+jhhLs375t4+L2p+hmhvPWEOuQrpQKYRV0DQuKOh6NvBKClaI8v6RA48jTf5yvoX6/yKjjVXuQ==",
             "dev": true,
             "requires": {
                 "colors": "^1.4.0",
                 "commander": "^7.2.0",
                 "fs-extra": "^9.1.0",
                 "jsonschema": "^1.4.0",
-                "langium": "0.3.0-next.5e9d27d",
+                "langium": "0.3.0-next.ee4fc4e",
                 "lodash": "^4.17.21"
             },
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dependencies": {
         "commander": "^8.0.0",
         "generator-langium": "^0.2.1",
-        "langium": "0.3.0-next.ee4fc4e",
+        "langium": "0.3.0",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0"
     },
@@ -60,7 +60,7 @@
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
         "eslint": "^7.19.0",
-        "langium-cli": "0.3.0-next.ee4fc4e",
+        "langium-cli": "0.3.0",
         "source-map-loader": "^3.0.0",
         "ts-loader": "^9.2.3",
         "typescript": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dependencies": {
         "commander": "^8.0.0",
         "generator-langium": "^0.2.1",
-        "langium": "0.3.0-next.5e9d27d",
+        "langium": "0.3.0-next.ee4fc4e",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0"
     },
@@ -60,7 +60,7 @@
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
         "eslint": "^7.19.0",
-        "langium-cli": "0.3.0-next.5e9d27d",
+        "langium-cli": "0.3.0-next.ee4fc4e",
         "source-map-loader": "^3.0.0",
         "ts-loader": "^9.2.3",
         "typescript": "^4.1.3",

--- a/src/cli/cli-util.ts
+++ b/src/cli/cli-util.ts
@@ -18,8 +18,7 @@ export async function extractDocument(fileName: string, extensions: string[], se
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
-    const buildResult = await services.shared.workspace.DocumentBuilder.build(document);
-    const validationErrors = buildResult.diagnostics.filter(e => e.severity === 1);
+    const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {
         success = false;
         console.error(colors.red('There are validation errors:'));

--- a/src/cli/cli-util.ts
+++ b/src/cli/cli-util.ts
@@ -4,6 +4,7 @@ import { LangiumDocument, LangiumServices } from 'langium';
 import path from 'path';
 import { URI } from 'vscode-uri';
 import { GenerateOptions } from '.';
+import { WorkspaceFolder } from 'vscode-languageserver';
 
 export async function extractDocument(fileName: string, extensions: string[], services: LangiumServices, options: GenerateOptions): Promise<GeneratorResult> {
     let success = true;
@@ -18,6 +19,8 @@ export async function extractDocument(fileName: string, extensions: string[], se
     }
 
     const document = services.shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(path.resolve(fileName)));
+    await services.shared.workspace.DocumentBuilder.build([document], { validationChecks: 'all' });
+
     const validationErrors = (document.diagnostics ?? []).filter(e => e.severity === 1);
     if (validationErrors.length > 0) {
         success = false;
@@ -37,6 +40,21 @@ export async function extractDocument(fileName: string, extensions: string[], se
         document: document,
         success: success
     }
+}
+
+
+export async function setRootFolder(fileName: string, services: LangiumServices, root?: string): Promise<void> {
+    if (!root) {
+        root = path.dirname(fileName);
+    }
+    if (!path.isAbsolute(root)) {
+        root = path.resolve(process.cwd(), root);
+    }
+    const folders: WorkspaceFolder[] = [{
+        name: path.basename(root),
+        uri: URI.file(root).toString()
+    }];
+    await services.shared.workspace.WorkspaceManager.initializeWorkspace(folders);
 }
 
 interface FilePathData {

--- a/src/cli/generator-html.ts
+++ b/src/cli/generator-html.ts
@@ -326,6 +326,7 @@ function footerFunc(element: Footer, ctx: GeneratorContext) {
 //#endregion
 
 function generateExpression(expression: Expression | SimpleExpression, ctx: GeneratorContext): string | number {
+    let expressionType = expression.$type
     if (isStringExpression(expression)) {
         return encodeHtml(expression.value);
     }
@@ -364,7 +365,7 @@ function generateExpression(expression: Expression | SimpleExpression, ctx: Gene
         }
     }
     else {
-        throw new Error('Unhandled Expression type: ' + expression.$type)
+        throw new Error('Unhandled Expression type: ' + expressionType)
     }
 }
 

--- a/src/cli/generator-js.ts
+++ b/src/cli/generator-js.ts
@@ -56,6 +56,7 @@ const generateJSFunctions: GenerateFunctions = {
 }
 
 function generateExpression(expression: Expression, ctx:GeneratorContext):string {
+    let expressionType = expression.$type
     if (isStringExpression(expression)){
         return expression.value
     }
@@ -72,7 +73,7 @@ function generateExpression(expression: Expression, ctx:GeneratorContext):string
         return `${generateExpression(expression.left, ctx)} ${expression.operator} ${generateExpression(expression.right, ctx)}`
     }
     else {
-        throw new Error ('Unhandled Expression type: ' + expression.$type)
+        throw new Error('Unhandled Expression type: ' + expressionType)
     }
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander';
 import { SimpleUiLanguageMetaData } from '../language-server/generated/module';
 import { SimpleUi } from '../language-server/generated/ast';
 import { createSimpleUiServices } from '../language-server/simple-ui-module';
-import { extractDocument } from './cli-util';
+import { extractDocument, setRootFolder } from './cli-util';
 import { generateHTML } from './generator-html';
 import { generateCSS } from './generator-css';
 import { generateJS } from './generator-js';
@@ -22,7 +22,7 @@ program
     .option('-w, --watch', 'enables watch mode', false)
     .description('generates HTML code based on the input')
     .action(async (fileName: string, opts: GenerateOptions) => {
-              progressCommand(fileName, opts);
+            progressCommand(fileName, opts);
     });
     
 program.parse(process.argv);
@@ -39,7 +39,9 @@ async function progressCommand(fileName: string, options: GenerateOptions) {
 }
 
 async function generate(fileName: string, options: GenerateOptions) {
-    const generationResult = await extractDocument(fileName, SimpleUiLanguageMetaData.fileExtensions, createSimpleUiServices().simpleUi, options);
+    const services = createSimpleUiServices().simpleUi;
+    await setRootFolder(fileName, services, options.destination);
+    const generationResult = await extractDocument(fileName, SimpleUiLanguageMetaData.fileExtensions, services, options);
     if(generationResult.success){
         const model = generationResult.document.parseResult?.value as SimpleUi;
         const generatedHTMLFilePath = generateHTML(model, fileName, options.destination);
@@ -53,7 +55,7 @@ async function generate(fileName: string, options: GenerateOptions) {
     else {
         console.log(getTime() + colors.red('Code generation failed'));
     }
- }
+}
 
 function getTime(): string{
     let dateTime = new Date()

--- a/src/language-server/simple-ui.langium
+++ b/src/language-server/simple-ui.langium
@@ -17,11 +17,11 @@ NestingElement:
 
 
 // List of single HTML Elements (HTML elements that do not contain other HTML elements). Add new ones here.
-SingleHTMLElement infer SingleElement:  
+SingleHTMLElement infers SingleElement:  
     Paragraph | Heading | Image | Textbox | Button | Link | Linebreak | Topbar | Footer;
 
 // List of nesting HTML Elements. Add new ones here.
-NestingHTMLElement infer NestingElement: 
+NestingHTMLElement infers NestingElement: 
     Div | Section;
 
 // CSS
@@ -88,19 +88,19 @@ Icon:
 Expression:
     Addition;
 
-Addition infer Expression:
+Addition infers Expression:
     Subtraction ({infer Operation.left=current} operator=('+') right=Subtraction)*;
 
-Subtraction infer Expression:
+Subtraction infers Expression:
     Division ({infer Operation.left=current} operator=('-') right=Division)*;
 
-Division infer Expression:
+Division infers Expression:
     Multiplication ({infer Operation.left=current} operator=('/') right=Multiplication)*;
 
-Multiplication infer Expression:
+Multiplication infers Expression:
     Primary ({infer Operation.left=current} operator=('*') right=Primary)*;
 
-Primary infer Expression:
+Primary infers Expression:
     TextboxExpression | '(' Addition ')';
 
 TextboxExpression:

--- a/src/language-server/simple-ui.langium
+++ b/src/language-server/simple-ui.langium
@@ -17,11 +17,11 @@ NestingElement:
 
 
 // List of single HTML Elements (HTML elements that do not contain other HTML elements). Add new ones here.
-SingleHTMLElement returns SingleElement:  
+SingleHTMLElement infer SingleElement:  
     Paragraph | Heading | Image | Textbox | Button | Link | Linebreak | Topbar | Footer;
 
 // List of nesting HTML Elements. Add new ones here.
-NestingHTMLElement returns NestingElement: 
+NestingHTMLElement infer NestingElement: 
     Div | Section;
 
 // CSS
@@ -64,7 +64,7 @@ Link:
     'link' ElementName? linkUrl=Expression ('text:' linkText=Expression)?;
 
 Linebreak:    
-    {Linebreak} 'linebreak';
+    {infer Linebreak} 'linebreak';
 
 Topbar:
     'topbar' value=Expression (fixed?='fixed')? ('navlinks:' ((autoNavLinks?='auto')|('['sectionsList+=[Section:ID](','sectionsList+=[Section:ID])*']')))?;
@@ -88,19 +88,19 @@ Icon:
 Expression:
     Addition;
 
-Addition returns Expression:
-    Subtraction ({Operation.left=current} operator=('+') right=Subtraction)*;
+Addition infer Expression:
+    Subtraction ({infer Operation.left=current} operator=('+') right=Subtraction)*;
 
-Subtraction returns Expression:
-    Division ({Operation.left=current} operator=('-') right=Division)*;
+Subtraction infer Expression:
+    Division ({infer Operation.left=current} operator=('-') right=Division)*;
 
-Division returns Expression:
-    Multiplication ({Operation.left=current} operator=('/') right=Multiplication)*;
+Division infer Expression:
+    Multiplication ({infer Operation.left=current} operator=('/') right=Multiplication)*;
 
-Multiplication returns Expression:
-    Primary ({Operation.left=current} operator=('*') right=Primary)*;
+Multiplication infer Expression:
+    Primary ({infer Operation.left=current} operator=('*') right=Primary)*;
 
-Primary returns Expression:
+Primary infer Expression:
     TextboxExpression | '(' Addition ')';
 
 TextboxExpression:


### PR DESCRIPTION
Due to the release of Langium 0.3.0 we can now upgrade to the final version directly and don't need to go to the next version first.